### PR TITLE
Run container as unprivileged user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,11 @@ RUN mkdir /opt/runtime-cache && \
     mkdir /opt/logs && \
     mkdir /opt/uploaded-files && \
     chown 33:33 /opt/* && \
-    chmod +x /var/www/html/docker/entrypoint.bash
+    chmod +x /var/www/html/docker/entrypoint.bash && \
+    mkdir /var/run/supervisor && \
+    chown www-data:www-data /var/log/supervisor/ /var/run/supervisor && \
+    sed -i 's|/var/run/|/var/run/supervisor/|g' /etc/supervisor/supervisord.conf
+
+USER 33:33
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/var/www/html/docker/entrypoint.bash"]

--- a/docker/entrypoint.bash
+++ b/docker/entrypoint.bash
@@ -17,16 +17,13 @@ cd /var/www/html || exit 1
 rm -rf var
 php bin/console cache:clear
 php bin/console cache:warmup
-chown -R 33:33 var
 
 [ ! -d "$DATABASE_DIR" ] && mkdir -p "$DATABASE_DIR"
-chown -R 33:33 "$DATABASE_DIR"
 php bin/console doctrine:migrations:migrate -n
-chmod -R 0777 "$DATABASE_DIR"
 
 php bin/console app:manage-objects --install
 
-/etc/init.d/supervisor start
+/usr/bin/supervisord
 supervisorctl reread
 supervisorctl update
 supervisorctl start messenger-consume:*


### PR DESCRIPTION
This avoids running scripts as root and the resulting permission issues.